### PR TITLE
[FEAT] 형식증명 채점 API 전체 구현 (#1)

### DIFF
--- a/src/main/java/com/proofy/proofy_api/checker/checker/ProofChecker.java
+++ b/src/main/java/com/proofy/proofy_api/checker/checker/ProofChecker.java
@@ -1,0 +1,104 @@
+package com.proofy.proofy_api.checker.checker;
+
+import com.proofy.proofy_api.checker.domain.line.Line;
+import com.proofy.proofy_api.checker.domain.line.LineNumber;
+import com.proofy.proofy_api.checker.domain.line.LineNumberType;
+import com.proofy.proofy_api.checker.domain.proof.Proof;
+import com.proofy.proofy_api.checker.dto.ProofErrorResponse;
+import com.proofy.proofy_api.checker.error.CheckError;
+import com.proofy.proofy_api.checker.error.ProofCheckException;
+import com.proofy.proofy_api.checker.rule.Rule;
+import com.proofy.proofy_api.checker.rule.RuleRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@AllArgsConstructor
+public class ProofChecker {
+
+    private final RuleRepository ruleRepository;
+
+    // 전체 증명 검증
+    public List<ProofErrorResponse> check(Proof proof) {
+
+        List<ProofErrorResponse> errors = new ArrayList<>();
+
+        // 1) 구조 검증
+        List<ProofErrorResponse> structureErrors = proof.validateStructure();
+        errors.addAll(structureErrors);
+
+        // 2) 각 라인 규칙 검증
+        for (Line line : proof.getLines()) {
+
+            // 파싱 실패 라인은 rule 검증 skip
+            if (line.isInvalid()) continue;
+
+            String ruleName = line.getCitation().getRuleName();
+            Rule rule = ruleRepository.get(ruleName);
+
+            // 존재하지 않는 규칙
+            if (rule == null) {
+                errors.add(new ProofErrorResponse(
+                        line.getNumber(),
+                        CheckError.NO_SUCH_RULE.name(),
+                        "Unknown rule: " + ruleName
+                ));
+                continue;
+            }
+
+            // (A) 규칙 시그니처 검증 (lineOrd 기반 operand 개수/type 체크)
+            try {
+                LineNumberType[] expected = rule.lineOrd();
+                List<LineNumber> actual = line.getCitation().getCites();
+
+                // operand 개수 불일치
+                if (expected.length != actual.size()) {
+                    errors.add(new ProofErrorResponse(
+                            line.getNumber(),
+                            CheckError.BAD_LINE_COUNT.name(),
+                            ruleName + " requires " + expected.length +
+                                    " operand(s), but got " + actual.size()
+                    ));
+                    continue;
+                }
+
+                // operand 타입 체크 (ONE / MANY)
+                for (int i = 0; i < expected.length; i++) {
+                    if (actual.get(i).getType() != expected[i]) {
+                        errors.add(new ProofErrorResponse(
+                                line.getNumber(),
+                                CheckError.BAD_LINE_TYPE.name(),
+                                ruleName + " operand " + (i + 1) +
+                                        " must be " + expected[i] +
+                                        " but was " + actual.get(i).getType()
+                        ));
+                    }
+                }
+
+            } catch (ProofCheckException ex) {
+                errors.add(new ProofErrorResponse(
+                        ex.getLine(),
+                        ex.getError().name(),
+                        ex.getMessage()
+                ));
+                continue;
+            }
+
+            // (B) 규칙의 실제 의미 검증 (isRight)
+            try {
+                rule.isRight(proof, line, errors);
+            } catch (ProofCheckException ex) {
+                errors.add(new ProofErrorResponse(
+                        ex.getLine(),
+                        ex.getError().name(),
+                        ex.getMessage()
+                ));
+            }
+        }
+
+        return errors;
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/controller/CheckerController.java
+++ b/src/main/java/com/proofy/proofy_api/checker/controller/CheckerController.java
@@ -1,0 +1,34 @@
+package com.proofy.proofy_api.checker.controller;
+
+import com.proofy.proofy_api.checker.dto.ProofCheckRequest;
+import com.proofy.proofy_api.checker.dto.ProofErrorResponse;
+import com.proofy.proofy_api.checker.dto.ProofResponse;
+import com.proofy.proofy_api.checker.service.CheckerService;
+import com.proofy.proofy_api.global.ApiResponse;
+import com.proofy.proofy_api.global.ErrorResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/checker")
+public class CheckerController {
+    private final CheckerService checkerService;
+
+    @PostMapping("/check")
+    public ResponseEntity<ProofResponse> checkProof(@RequestBody ProofCheckRequest request) {
+
+        List<ProofErrorResponse> errors = checkerService.checkProof(request);
+
+        if (errors.isEmpty()) {
+            return ResponseEntity.ok(ProofResponse.ok());
+        } else {
+            return ResponseEntity
+                    .badRequest()
+                    .body(ProofResponse.fail(errors));
+        }
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/domain/line/Citation.java
+++ b/src/main/java/com/proofy/proofy_api/checker/domain/line/Citation.java
@@ -1,0 +1,13 @@
+package com.proofy.proofy_api.checker.domain.line;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@AllArgsConstructor
+@Getter
+public class Citation {
+    private final String ruleName;          // ※ "^I", "→I", "¬E" 등
+    private final List<LineNumber> cites;   // ※ 라인 인용 목록
+}

--- a/src/main/java/com/proofy/proofy_api/checker/domain/line/Line.java
+++ b/src/main/java/com/proofy/proofy_api/checker/domain/line/Line.java
@@ -1,0 +1,43 @@
+package com.proofy.proofy_api.checker.domain.line;
+
+import com.proofy.proofy_api.checker.domain.sentence.Sentence;
+import com.proofy.proofy_api.checker.error.ProofParseException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class Line {
+
+    private final int number;
+    private final int depth;
+    private final Sentence sentence;
+    private final Citation citation;
+    private final boolean invalid;
+
+    public Line(int number, int depth, Sentence sentence, Citation citation) {
+        this.number = number;
+        this.depth = depth;
+        this.sentence = sentence;
+        this.citation = citation;
+        this.invalid = false;
+    }
+
+    public static Line invalid(int number, int depth) {
+        return new Line(number, depth, null, null, true);
+    }
+
+    public boolean isAssumption() {
+        String r = citation.getRuleName();
+
+        // ★ 핵심 FIX
+        if (this.depth > 0 && "PR".equals(r)) {
+            return true;
+        }
+
+        return switch (r) {
+            case "→I", "¬I", "∨E", "IP", "⊥I" -> true;
+            default -> false;
+        };
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/domain/line/LineNumber.java
+++ b/src/main/java/com/proofy/proofy_api/checker/domain/line/LineNumber.java
@@ -1,0 +1,25 @@
+package com.proofy.proofy_api.checker.domain.line;
+
+import com.proofy.proofy_api.checker.error.CheckError;
+import com.proofy.proofy_api.checker.error.ProofCheckException;
+
+public sealed interface LineNumber
+        permits OneLineNumber, RangeLineNumber {
+
+    int getOriginLine();
+
+    LineNumberType getType();    // 규칙(lineOrd)에서 type 검사용
+
+    // ONE 라인 인용을 기대할 때 호출
+    default int asOne() {
+        throw new ProofCheckException(CheckError.BAD_LINE_TYPE, getOriginLine());
+    }
+
+    // MANY(subproof) 라인 인용을 기대할 때 호출
+    default Range asRange() {
+        throw new ProofCheckException(CheckError.BAD_LINE_TYPE, getOriginLine());
+    }
+
+    // Range 반환용 record
+    record Range(int start, int end) {}
+}

--- a/src/main/java/com/proofy/proofy_api/checker/domain/line/LineNumberType.java
+++ b/src/main/java/com/proofy/proofy_api/checker/domain/line/LineNumberType.java
@@ -1,0 +1,6 @@
+package com.proofy.proofy_api.checker.domain.line;
+
+public enum LineNumberType {
+    ONE,
+    MANY // subproof 용
+}

--- a/src/main/java/com/proofy/proofy_api/checker/domain/line/OneLineNumber.java
+++ b/src/main/java/com/proofy/proofy_api/checker/domain/line/OneLineNumber.java
@@ -1,0 +1,26 @@
+package com.proofy.proofy_api.checker.domain.line;
+
+import com.proofy.proofy_api.checker.error.CheckError;
+import com.proofy.proofy_api.checker.error.ProofCheckException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@AllArgsConstructor
+@Getter
+@Setter
+public final class OneLineNumber implements LineNumber{
+    private final int originLine;
+    private final int number;     // ※ ex) 3
+
+    @Override
+    public LineNumberType getType() { return LineNumberType.ONE; }
+
+    @Override
+    public int asOne() {
+        if (number <= 0) {
+            throw new ProofCheckException(CheckError.BAD_LINE, originLine); // 0 이하 라인 인용 불가
+        }
+        return number;
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/domain/line/RangeLineNumber.java
+++ b/src/main/java/com/proofy/proofy_api/checker/domain/line/RangeLineNumber.java
@@ -1,0 +1,27 @@
+package com.proofy.proofy_api.checker.domain.line;
+
+import com.proofy.proofy_api.checker.error.CheckError;
+import com.proofy.proofy_api.checker.error.ProofCheckException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@AllArgsConstructor
+@Getter
+@Setter
+public final class RangeLineNumber implements LineNumber{
+    private final int originLine;
+    private final int start;      // subproof 시작 라인
+    private final int end;        // subproof 끝 라인
+
+    @Override
+    public LineNumberType getType() { return LineNumberType.MANY; }
+
+    @Override
+    public Range asRange() {
+        if (start <= 0 || end <= 0 || start > end) {
+            throw new ProofCheckException(CheckError.BAD_RANGE, originLine);
+        }
+        return new Range(start, end); // 내부 record 사용
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/domain/proof/Proof.java
+++ b/src/main/java/com/proofy/proofy_api/checker/domain/proof/Proof.java
@@ -1,0 +1,160 @@
+package com.proofy.proofy_api.checker.domain.proof;
+
+import com.proofy.proofy_api.checker.domain.line.Line;
+import com.proofy.proofy_api.checker.dto.ProofErrorResponse;
+import com.proofy.proofy_api.checker.dto.SubproofResult;
+import com.proofy.proofy_api.checker.rule.AbstractRule;
+import com.proofy.proofy_api.checker.error.CheckError;
+import com.proofy.proofy_api.checker.error.ProofCheckException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+
+import static com.proofy.proofy_api.checker.error.CheckError.BAD_RANGE;
+
+@AllArgsConstructor
+@Getter
+@Setter
+public class Proof {
+
+    private final List<Line> lines;
+    public int size() { return lines.size(); }
+    public Line line1Based(int n) { return lines.get(n - 1); }
+
+    public SubproofResult extractSubproof(Line useLine, int start, int end) {
+        List<ProofErrorResponse> errors = new ArrayList<>();
+
+        // 기본 유효성: start ~ end 범위는 존재해야 함
+        if (start < 1 || end < start)
+            errors.add(new ProofErrorResponse(useLine.getNumber(), BAD_RANGE.name(), "기본 유효성 에러: start ~ end 범위는 존재해야 함"));
+
+        Line startLine = line1Based(start);
+        Line endLine = line1Based(end);
+
+        int depth = startLine.getDepth();
+
+        // ★ subproof는 depth >= 1 이어야 함
+        if (depth < 1)
+            errors.add(new ProofErrorResponse(useLine.getNumber(), BAD_RANGE.name(), "subproof는 depth >= 1 이어야 함"));
+
+        // ★ subproof의 시작과 끝 depth는 동일해야 함
+        if (endLine.getDepth() != depth)
+            errors.add(new ProofErrorResponse(useLine.getNumber(), BAD_RANGE.name(), "subproof의 시작과 끝 depth는 동일해야 함"));
+
+        // ★ subproof 내부는 depth가 감소하면 안 됨
+        for (int i = start + 1; i <= end; i++) {
+            Line mid = line1Based(i);
+            if (mid.getDepth() < depth)
+                errors.add(new ProofErrorResponse(useLine.getNumber(), BAD_RANGE.name(), "subproof 내부는 depth가 감소하면 안 됨"));
+        }
+
+        // ★ subproof conclusion 다음 라인(depth 감소)는 검사하지 않는다
+        // 교재식 자연연역에서는 바로 다음 subproof가 와도 정상임.
+
+        if (errors.isEmpty())
+            return new SubproofResult(new AbstractRule.Subproof(startLine.getSentence(), endLine.getSentence()), null);
+        else return new SubproofResult(null, errors);
+    }
+
+    public List<ProofErrorResponse> validateStructure() {
+        List<ProofErrorResponse> errors = new ArrayList<>();
+
+        Deque<Integer> stack = new ArrayDeque<>();
+        int prevDepth = 0;
+        int expectedNumber = 1;
+
+        for (Line line : lines) {
+            int depth = line.getDepth();
+            int num = line.getNumber();
+
+            // ------------------------------
+            // 0) Line 번호 오름차순 검증
+            // ------------------------------
+            if (num != expectedNumber) {
+                errors.add(new ProofErrorResponse(
+                        num,
+                        CheckError.INVALID_PROOF_STRUCTURE.name(),
+                        String.format(
+                                "Line 번호가 순차적으로 증가하지 않습니다. expected=%d, actual=%d",
+                                expectedNumber, num
+                        )
+                ));
+            }
+            expectedNumber++;
+
+            // ------------------------------
+            // 1) depth < 0 (불가능)
+            // ------------------------------
+            if (depth < 0) {
+                errors.add(new ProofErrorResponse(
+                        num,
+                        CheckError.BAD_RANGE.name(),
+                        "Depth cannot be negative (line " + num + ", depth=" + depth + ")"
+                ));
+                prevDepth = depth;
+                continue;
+            }
+
+            // ------------------------------
+            // 2) depth jump > 1 (불가능)
+            // ex: depth 0 → 2 점프 같은 경우
+            // ------------------------------
+            if (depth > prevDepth + 1) {
+                errors.add(new ProofErrorResponse(
+                        num,
+                        CheckError.BAD_RANGE.name(),
+                        "Invalid depth jump from " + prevDepth + " to " + depth + " at line " + num
+                ));
+            }
+
+            // ------------------------------
+            // 3) 새 subproof 시작 (depth 증가)
+            // ------------------------------
+            if (depth == prevDepth + 1) {
+                if (!line.isInvalid()) {
+                    if (!line.isAssumption()) {
+                        errors.add(new ProofErrorResponse(
+                                num,
+                                CheckError.BAD_RANGE.name(),
+                                "Depth increased from " + prevDepth + " to " + depth +
+                                        " but line " + num + " is not an assumption."
+                        ));
+                    }
+                    stack.push(num);
+                }
+            }
+
+            // ------------------------------
+            // 4) subproof 닫힘 (depth 감소)
+            // ------------------------------
+            else if (depth < prevDepth) {
+                while (stack.size() > depth) {
+                    stack.pop();
+                }
+            }
+
+            // depth == prevDepth → ok, 아무 것도 안 함
+
+            prevDepth = depth;
+        }
+
+        // ------------------------------
+        // 5) subproof가 열린 채로 끝나면 오류
+        // ------------------------------
+        if (!stack.isEmpty()) {
+            int last = lines.get(lines.size() - 1).getNumber();
+            errors.add(new ProofErrorResponse(
+                    last,
+                    CheckError.BAD_RANGE.name(),
+                    "Unclosed subproof detected at line " + last
+            ));
+        }
+
+        return errors;
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/domain/sentence/AtomSentence.java
+++ b/src/main/java/com/proofy/proofy_api/checker/domain/sentence/AtomSentence.java
@@ -1,0 +1,18 @@
+package com.proofy.proofy_api.checker.domain.sentence;
+
+import lombok.AllArgsConstructor;
+
+// A
+@AllArgsConstructor
+public final class AtomSentence implements Sentence{
+    private final String name;                   // ※ "A", "B", "P", "Q" 등
+
+    @Override
+    public boolean structurallyEquals(Sentence other) {
+        return (other instanceof AtomSentence a) &&
+                a.name.equals(this.name);
+    }
+
+    @Override
+    public String toString() { return name; }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/domain/sentence/BicSentence.java
+++ b/src/main/java/com/proofy/proofy_api/checker/domain/sentence/BicSentence.java
@@ -1,0 +1,24 @@
+package com.proofy.proofy_api.checker.domain.sentence;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+// A ↔ B
+@Getter
+@AllArgsConstructor
+public final class BicSentence implements Sentence {
+    private final Sentence left;
+    private final Sentence right;
+
+    @Override
+    public boolean structurallyEquals(Sentence other) {
+        if (!(other instanceof BicSentence o)) return false;
+        return left.structurallyEquals(o.left) &&
+                right.structurallyEquals(o.right);
+    }
+
+    @Override
+    public String toString() {
+        return "(" + left + " ↔ " + right + ")";
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/domain/sentence/BotSentence.java
+++ b/src/main/java/com/proofy/proofy_api/checker/domain/sentence/BotSentence.java
@@ -1,0 +1,14 @@
+package com.proofy.proofy_api.checker.domain.sentence;
+
+public final class BotSentence implements Sentence {
+
+    @Override
+    public boolean structurallyEquals(Sentence other) {
+        return other instanceof BotSentence;
+    }
+
+    @Override
+    public String toString() {
+        return "⊥";
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/domain/sentence/ConSentence.java
+++ b/src/main/java/com/proofy/proofy_api/checker/domain/sentence/ConSentence.java
@@ -1,0 +1,24 @@
+package com.proofy.proofy_api.checker.domain.sentence;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+// A ∧ B
+@Getter
+@AllArgsConstructor
+public final class ConSentence implements Sentence {
+    private final Sentence left;
+    private final Sentence right;
+
+    @Override
+    public boolean structurallyEquals(Sentence other) {
+        if (!(other instanceof ConSentence o)) return false;
+        return left.structurallyEquals(o.left) &&
+                right.structurallyEquals(o.right);
+    }
+
+    @Override
+    public String toString() {
+        return "(" + left + " ∧ " + right + ")";
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/domain/sentence/DisSentence.java
+++ b/src/main/java/com/proofy/proofy_api/checker/domain/sentence/DisSentence.java
@@ -1,0 +1,24 @@
+package com.proofy.proofy_api.checker.domain.sentence;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+// A ∨ B
+@Getter
+@AllArgsConstructor
+public final class DisSentence implements Sentence {
+    private final Sentence left;
+    private final Sentence right;
+
+    @Override
+    public boolean structurallyEquals(Sentence other) {
+        if (!(other instanceof DisSentence o)) return false;
+        return left.structurallyEquals(o.left) &&
+                right.structurallyEquals(o.right);
+    }
+
+    @Override
+    public String toString() {
+        return "(" + left + " ∨ " + right + ")";
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/domain/sentence/ImpSentence.java
+++ b/src/main/java/com/proofy/proofy_api/checker/domain/sentence/ImpSentence.java
@@ -1,0 +1,24 @@
+package com.proofy.proofy_api.checker.domain.sentence;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+// A → B
+@Getter
+@AllArgsConstructor
+public final class ImpSentence implements Sentence {
+    private final Sentence left;   // antecedent
+    private final Sentence right;  // consequent
+
+    @Override
+    public boolean structurallyEquals(Sentence other) {
+        if (!(other instanceof ImpSentence o)) return false;
+        return left.structurallyEquals(o.left) &&
+                right.structurallyEquals(o.right);
+    }
+
+    @Override
+    public String toString() {
+        return "(" + left + " → " + right + ")";
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/domain/sentence/NegSentence.java
+++ b/src/main/java/com/proofy/proofy_api/checker/domain/sentence/NegSentence.java
@@ -1,0 +1,21 @@
+package com.proofy.proofy_api.checker.domain.sentence;
+
+// ¬A
+public final class NegSentence implements Sentence {
+    private final Sentence inner;                // ※ ¬S 의 S
+
+    public NegSentence(Sentence inner) {
+        this.inner = inner;
+    }
+
+    public Sentence inner() { return inner; }    // ※ 규칙에서 내부 식 비교할 때 사용
+
+    @Override
+    public boolean structurallyEquals(Sentence other) {
+        return (other instanceof NegSentence n) &&
+                n.inner.structurallyEquals(inner);
+    }
+
+    @Override
+    public String toString() { return "¬" + inner; }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/domain/sentence/Sentence.java
+++ b/src/main/java/com/proofy/proofy_api/checker/domain/sentence/Sentence.java
@@ -1,0 +1,19 @@
+package com.proofy.proofy_api.checker.domain.sentence;
+
+public sealed interface Sentence permits AtomSentence, BicSentence, BotSentence, ConSentence, DisSentence, ImpSentence, NegSentence {
+    // (1) 논리식 문자열 표현용
+    String toString();  // ※ AST를 문자열로 재출력하기 위한 메소드
+
+    // (2) 두 문장이 구조적으로 같은지 비교
+    boolean structurallyEquals(Sentence other); // ※ 패턴 매칭 규칙 검증용
+
+    // (3) 편의 메소드: ¬S 생성
+    default Sentence negate() {                  // ※ 규칙에서 자주 쓰임 (ex. ¬E)
+        return new NegSentence(this);
+    }
+
+    // (4) 편의 메소드: ⊥ 판별
+    default boolean isBotSignal() {        // ⊥ 판별
+        return this instanceof BotSentence;
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/dto/LineRequest.java
+++ b/src/main/java/com/proofy/proofy_api/checker/dto/LineRequest.java
@@ -1,0 +1,9 @@
+package com.proofy.proofy_api.checker.dto;
+
+public record LineRequest(
+        Integer number,
+        Integer depth,
+        String sentence,
+        String citation
+) {
+}

--- a/src/main/java/com/proofy/proofy_api/checker/dto/ProofCheckRequest.java
+++ b/src/main/java/com/proofy/proofy_api/checker/dto/ProofCheckRequest.java
@@ -1,0 +1,12 @@
+package com.proofy.proofy_api.checker.dto;
+
+import com.proofy.proofy_api.checker.domain.sentence.Sentence;
+
+import java.util.List;
+
+public record ProofCheckRequest(
+        List<String> premises,
+        String conclusion,
+        List<LineRequest> lines
+) {
+}

--- a/src/main/java/com/proofy/proofy_api/checker/dto/ProofErrorResponse.java
+++ b/src/main/java/com/proofy/proofy_api/checker/dto/ProofErrorResponse.java
@@ -1,0 +1,8 @@
+package com.proofy.proofy_api.checker.dto;
+
+public record ProofErrorResponse(
+        int line,
+        String code,
+        String message
+) {
+}

--- a/src/main/java/com/proofy/proofy_api/checker/dto/ProofResponse.java
+++ b/src/main/java/com/proofy/proofy_api/checker/dto/ProofResponse.java
@@ -1,0 +1,16 @@
+package com.proofy.proofy_api.checker.dto;
+
+import java.util.List;
+
+public record ProofResponse(
+        boolean success,
+        List<ProofErrorResponse> errors
+) {
+    public static ProofResponse ok() {
+        return new ProofResponse(true, List.of());
+    }
+
+    public static ProofResponse fail(List<ProofErrorResponse> errors) {
+        return new ProofResponse(false, errors);
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/dto/SubproofResult.java
+++ b/src/main/java/com/proofy/proofy_api/checker/dto/SubproofResult.java
@@ -1,0 +1,14 @@
+package com.proofy.proofy_api.checker.dto;
+
+import com.proofy.proofy_api.checker.rule.AbstractRule;
+
+import java.util.List;
+
+public record SubproofResult(
+        AbstractRule.Subproof subproof,   // 성공 시 채워짐
+        List<ProofErrorResponse> errors   // 실패 시 채워짐
+) {
+    public boolean hasErrors() {
+        return errors != null && !errors.isEmpty();
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/error/CheckError.java
+++ b/src/main/java/com/proofy/proofy_api/checker/error/CheckError.java
@@ -1,0 +1,12 @@
+package com.proofy.proofy_api.checker.error;
+
+public enum CheckError {
+    NO_SUCH_RULE,        // 존재하지 않는 규칙
+    BAD_LINE_COUNT,      // 라인 인용 개수 불일치
+    BAD_LINE_TYPE,       // ONE vs MANY 타입 불일치
+    BAD_USAGE,           // 규칙 자체 적용 실패
+    BAD_LINE,            // 미래 라인 인용, self 인용 등
+    BAD_RANGE,           // subproof 범위 이상함
+    UNAVAILABLE,         // 접근 불가 라인 인용
+    INVALID_PROOF_STRUCTURE // 구조 자체가 이상함
+}

--- a/src/main/java/com/proofy/proofy_api/checker/error/ParseError.java
+++ b/src/main/java/com/proofy/proofy_api/checker/error/ParseError.java
@@ -1,0 +1,6 @@
+package com.proofy.proofy_api.checker.error;
+
+public enum ParseError {
+    INVALID_SENTENCE,   // 논리식 파싱 실패
+    INVALID_CITATION   // 규칙 인용 파싱 실패
+}

--- a/src/main/java/com/proofy/proofy_api/checker/error/ProofCheckException.java
+++ b/src/main/java/com/proofy/proofy_api/checker/error/ProofCheckException.java
@@ -1,0 +1,11 @@
+package com.proofy.proofy_api.checker.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProofCheckException extends RuntimeException{
+    private final CheckError error;
+    private final int line;
+}

--- a/src/main/java/com/proofy/proofy_api/checker/error/ProofParseException.java
+++ b/src/main/java/com/proofy/proofy_api/checker/error/ProofParseException.java
@@ -1,0 +1,11 @@
+package com.proofy.proofy_api.checker.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProofParseException extends RuntimeException{
+    private final ParseError error;
+    private final int originLine;
+}

--- a/src/main/java/com/proofy/proofy_api/checker/parser/CitationParser.java
+++ b/src/main/java/com/proofy/proofy_api/checker/parser/CitationParser.java
@@ -1,0 +1,60 @@
+package com.proofy.proofy_api.checker.parser;
+
+import com.proofy.proofy_api.checker.domain.line.*;
+import com.proofy.proofy_api.checker.error.ParseError;
+import com.proofy.proofy_api.checker.error.ProofParseException;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class CitationParser {
+
+    public Citation parse(String raw, int originLine) {
+        raw = raw.trim();
+
+        if (raw.isEmpty()) {
+            return new Citation("", List.of());
+        }
+
+        String[] parts = raw.split("\\s+");
+
+        String ruleName = parts[0];
+        List<LineNumber> cites = new ArrayList<>();
+
+        if (parts.length == 1) {
+            return new Citation(ruleName, cites);
+        }
+
+        for (int i = 1; i < parts.length; i++) {
+            String token = parts[i];
+
+            if (token.contains("-")) {
+                String[] lr = token.split("-");
+                if (lr.length != 2)
+                    throw new ProofParseException(ParseError.INVALID_CITATION, originLine);
+
+                int start = parseInt(lr[0], originLine);
+                int end   = parseInt(lr[1], originLine);
+
+                cites.add(new RangeLineNumber(originLine, start, end));
+
+            } else {
+                int one = parseInt(token, originLine);
+                cites.add(new OneLineNumber(originLine, one));
+            }
+        }
+
+        return new Citation(ruleName, cites);
+    }
+
+    private int parseInt(String s, int originLine) {
+        try {
+            return Integer.parseInt(s);
+        } catch (NumberFormatException ex) {
+            throw new ProofParseException(ParseError.INVALID_CITATION, originLine);
+        }
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/parser/SentenceParser.java
+++ b/src/main/java/com/proofy/proofy_api/checker/parser/SentenceParser.java
@@ -1,0 +1,109 @@
+package com.proofy.proofy_api.checker.parser;
+
+import com.proofy.proofy_api.checker.domain.sentence.*;
+import com.proofy.proofy_api.checker.error.ParseError;
+import com.proofy.proofy_api.checker.error.ProofParseException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SentenceParser {
+
+    public Sentence parse(String raw, int originLine) {
+        raw = raw.trim();
+
+        // 1) 바깥 괄호가 전체 문장을 감싸는 경우에만 제거
+        raw = stripOuterParens(raw);
+
+        // 2) 연산자 우선순위: ↔ → ∨ ∧  (항상 top-level에서만 찾아야 함)
+        int idx;
+
+        // ↔
+        idx = findMainOperator(raw, "↔");
+        if (idx != -1) {
+            return new BicSentence(
+                    parse(raw.substring(0, idx).trim(), originLine),
+                    parse(raw.substring(idx + 1).trim(), originLine)
+            );
+        }
+
+        // →
+        idx = findMainOperator(raw, "→");
+        if (idx != -1) {
+            return new ImpSentence(
+                    parse(raw.substring(0, idx).trim(), originLine),
+                    parse(raw.substring(idx + 1).trim(), originLine)
+            );
+        }
+
+        // ∨
+        idx = findMainOperator(raw, "∨");
+        if (idx != -1) {
+            return new DisSentence(
+                    parse(raw.substring(0, idx).trim(), originLine),
+                    parse(raw.substring(idx + 1).trim(), originLine)
+            );
+        }
+
+        // ∧
+        idx = findMainOperator(raw, "∧");
+        if (idx != -1) {
+            return new ConSentence(
+                    parse(raw.substring(0, idx).trim(), originLine),
+                    parse(raw.substring(idx + 1).trim(), originLine)
+            );
+        }
+
+        // ¬ 또는 ~
+        if (raw.startsWith("¬") || raw.startsWith("~")) {
+            return new NegSentence(parse(raw.substring(1).trim(), originLine));
+        }
+
+        // ⊥ 또는 #
+        if (raw.equals("⊥") || raw.equals("#")) {
+            return new BotSentence();
+        }
+
+        // Atom
+        if (raw.matches("[A-Za-z][A-Za-z0-9]*")) {
+            return new AtomSentence(raw);
+        }
+
+        throw new ProofParseException(ParseError.INVALID_SENTENCE, originLine);
+    }
+
+    /** 괄호가 전체 문장을 감싸는 경우에만 제거 */
+    private String stripOuterParens(String raw) {
+        if (!raw.startsWith("(") || !raw.endsWith(")")) return raw;
+
+        int depth = 0;
+        for (int i = 0; i < raw.length(); i++) {
+            char c = raw.charAt(i);
+            if (c == '(') depth++;
+            else if (c == ')') depth--;
+
+            if (depth == 0 && i != raw.length() - 1) {
+                return raw; // 바깥을 완전히 감싸는 괄호가 아님
+            }
+        }
+        // 완전 외곽 괄호
+        return raw.substring(1, raw.length() - 1).trim();
+    }
+
+    /** top-level 연산자(괄호 깊이 0)만 찾는 함수 */
+    int findMainOperator(String raw, String symbol) {
+        int depth = 0;
+        int len = symbol.length();
+
+        for (int i = 0; i < raw.length() - len + 1; i++) {
+            char c = raw.charAt(i);
+
+            if (c == '(') depth++;
+            else if (c == ')') depth--;
+
+            if (depth == 0 && raw.startsWith(symbol, i)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/rule/AbstractRule.java
+++ b/src/main/java/com/proofy/proofy_api/checker/rule/AbstractRule.java
@@ -1,0 +1,39 @@
+package com.proofy.proofy_api.checker.rule;
+
+import com.proofy.proofy_api.checker.domain.line.Line;
+import com.proofy.proofy_api.checker.domain.line.LineNumber;
+import com.proofy.proofy_api.checker.domain.proof.Proof;
+import com.proofy.proofy_api.checker.domain.sentence.Sentence;
+import com.proofy.proofy_api.checker.dto.ProofErrorResponse;
+import com.proofy.proofy_api.checker.dto.SubproofResult;
+
+import java.util.List;
+
+public abstract class AbstractRule implements Rule {
+
+    // ONE citation sentence
+    protected Sentence citedSentence(Proof proof, Line line, int index) {
+        LineNumber ln = line.getCitation().getCites().get(index);
+        int n = ln.asOne();
+        return proof.line1Based(n).getSentence();
+    }
+
+    // MANY citation => subproof
+    protected Subproof citedSubproof(Proof proof, Line line, int index, List<ProofErrorResponse> errors) {
+        var range = line.getCitation().getCites().get(index).asRange();
+        SubproofResult result = proof.extractSubproof(line, range.start(), range.end());
+
+        if (result.hasErrors()) {
+            errors.addAll(result.errors());
+            return null;
+        }
+
+        return result.subproof();
+    }
+
+    protected boolean same(Sentence a, Sentence b) {
+        return a.structurallyEquals(b);
+    }
+
+    public record Subproof(Sentence premise, Sentence conclusion) {}
+}

--- a/src/main/java/com/proofy/proofy_api/checker/rule/BasicRuleSet.java
+++ b/src/main/java/com/proofy/proofy_api/checker/rule/BasicRuleSet.java
@@ -1,0 +1,27 @@
+package com.proofy.proofy_api.checker.rule;
+
+import com.proofy.proofy_api.checker.rule.impl.*;
+
+import java.util.Map;
+
+import static java.util.Map.entry;
+
+public class BasicRuleSet {
+
+    public static final Map<String, Rule> RULES = Map.ofEntries(
+            entry("PR", new PR()),          // Premise
+            entry("R",  new R()),           // Reiteration
+            entry("∧I", new ConI()),        // Conjunction Introduction
+            entry("∧E", new ConE()),        // Conjunction Elimination
+            entry("∨I", new DisI()),        // Disjunction Introduction
+            entry("∨E", new DisE()),        // Disjunction Elimination
+            entry("→I", new ImpI()),        // Conditional Introduction
+            entry("→E", new ImpE()),        // Conditional Elimination
+            entry("↔I", new BicI()),        // Biconditional Introduction
+            entry("↔E", new BicE()),        // Biconditional Elimination
+            entry("¬I", new NegI()),        // Negation Introduction
+            entry("¬E", new NegE()),        // Negation Elimination
+            entry("⊥I", new ContraI()),     // Contradiction Introduction
+            entry("⊥E",  new ContraE())     // Contradiction Elimination
+    );
+}

--- a/src/main/java/com/proofy/proofy_api/checker/rule/Rule.java
+++ b/src/main/java/com/proofy/proofy_api/checker/rule/Rule.java
@@ -1,0 +1,18 @@
+package com.proofy.proofy_api.checker.rule;
+
+import com.proofy.proofy_api.checker.dto.ProofErrorResponse;
+import com.proofy.proofy_api.checker.error.CheckError;
+import com.proofy.proofy_api.checker.domain.line.Line;
+import com.proofy.proofy_api.checker.domain.line.LineNumberType;
+import com.proofy.proofy_api.checker.domain.proof.Proof;
+import com.proofy.proofy_api.checker.error.ProofCheckException;
+
+import java.util.List;
+
+public interface Rule {
+
+    LineNumberType[] lineOrd();  // expected citation types
+
+    // is_right
+    void isRight(Proof proof, Line line, List<ProofErrorResponse> errors);
+}

--- a/src/main/java/com/proofy/proofy_api/checker/rule/RuleRepository.java
+++ b/src/main/java/com/proofy/proofy_api/checker/rule/RuleRepository.java
@@ -1,0 +1,34 @@
+package com.proofy.proofy_api.checker.rule;
+
+import com.proofy.proofy_api.checker.rule.BasicRuleSet;
+import com.proofy.proofy_api.checker.rule.Rule;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@Repository
+public class RuleRepository {
+
+    private final Map<String, Rule> rules = new HashMap<>();
+
+    public RuleRepository() {
+        rules.putAll(BasicRuleSet.RULES);
+    }
+
+    // 룰 추가
+    public void addRules(Map<String, Rule> rules) {
+        rules.putAll(rules);
+    }
+
+    // 룰 조회
+    public Rule get(String name) {
+        return rules.get(name);
+    }
+
+    public boolean contains(String name) {
+        return rules.containsKey(name);
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/rule/impl/BicE.java
+++ b/src/main/java/com/proofy/proofy_api/checker/rule/impl/BicE.java
@@ -1,0 +1,39 @@
+package com.proofy.proofy_api.checker.rule.impl;
+
+import com.proofy.proofy_api.checker.domain.line.LineNumberType;
+import com.proofy.proofy_api.checker.domain.line.Line;
+import com.proofy.proofy_api.checker.domain.proof.Proof;
+import com.proofy.proofy_api.checker.domain.sentence.BicSentence;
+import com.proofy.proofy_api.checker.domain.sentence.Sentence;
+import com.proofy.proofy_api.checker.dto.ProofErrorResponse;
+import com.proofy.proofy_api.checker.error.CheckError;
+import com.proofy.proofy_api.checker.error.ProofCheckException;
+import com.proofy.proofy_api.checker.rule.AbstractRule;
+
+import java.util.List;
+
+public class BicE extends AbstractRule {
+
+    @Override
+    public LineNumberType[] lineOrd() {
+        return new LineNumberType[]{ LineNumberType.ONE, LineNumberType.ONE };
+    }
+
+    @Override
+    public void isRight(Proof proof, Line line, List<ProofErrorResponse> errors) {
+
+        Sentence s1 = citedSentence(proof, line, 0);
+        Sentence s2 = citedSentence(proof, line, 1);
+        Sentence tgt = line.getSentence();
+
+        if (!(s1 instanceof BicSentence bic))
+            throw new ProofCheckException(CheckError.BAD_USAGE, line.getNumber());
+
+        boolean ok =
+                (same(bic.getLeft(), s2) && same(bic.getRight(), tgt)) ||
+                        (same(bic.getRight(), s2) && same(bic.getLeft(), tgt));
+
+        if (!ok)
+            throw new ProofCheckException(CheckError.BAD_USAGE, line.getNumber());
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/rule/impl/BicI.java
+++ b/src/main/java/com/proofy/proofy_api/checker/rule/impl/BicI.java
@@ -1,0 +1,50 @@
+package com.proofy.proofy_api.checker.rule.impl;
+
+import com.proofy.proofy_api.checker.dto.ProofErrorResponse;
+import com.proofy.proofy_api.checker.error.CheckError;
+import com.proofy.proofy_api.checker.domain.line.LineNumberType;
+import com.proofy.proofy_api.checker.domain.line.Line;
+import com.proofy.proofy_api.checker.domain.proof.Proof;
+import com.proofy.proofy_api.checker.domain.sentence.BicSentence;
+import com.proofy.proofy_api.checker.domain.sentence.Sentence;
+import com.proofy.proofy_api.checker.error.ProofCheckException;
+import com.proofy.proofy_api.checker.rule.AbstractRule;
+
+import java.util.List;
+
+public class BicI extends AbstractRule {
+
+    @Override
+    public LineNumberType[] lineOrd() {
+        return new LineNumberType[]{ LineNumberType.MANY, LineNumberType.MANY };
+    }
+
+    @Override
+    public void isRight(Proof proof, Line line, List<ProofErrorResponse> errors) {
+
+        Subproof sp1 = citedSubproof(proof, line, 0, errors); // A → B
+        Subproof sp2 = citedSubproof(proof, line, 1, errors); // B → A
+        if (sp1 == null || sp2 == null) return;
+
+        if (!(line.getSentence() instanceof BicSentence bic))
+            throw new ProofCheckException(CheckError.BAD_USAGE, line.getNumber());
+
+        Sentence A = bic.getLeft();
+        Sentence B = bic.getRight();
+
+        boolean ok1 =
+                same(sp1.premise(), A) &&
+                        same(sp1.conclusion(), B) &&
+                        same(sp2.premise(), B) &&
+                        same(sp2.conclusion(), A);
+
+        boolean ok2 =
+                same(sp1.premise(), B) &&
+                        same(sp1.conclusion(), A) &&
+                        same(sp2.premise(), A) &&
+                        same(sp2.conclusion(), B);
+
+        if (!(ok1 || ok2))
+            throw new ProofCheckException(CheckError.BAD_USAGE, line.getNumber());
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/rule/impl/ConE.java
+++ b/src/main/java/com/proofy/proofy_api/checker/rule/impl/ConE.java
@@ -1,0 +1,34 @@
+package com.proofy.proofy_api.checker.rule.impl;
+
+import com.proofy.proofy_api.checker.domain.line.LineNumberType;
+import com.proofy.proofy_api.checker.domain.line.Line;
+import com.proofy.proofy_api.checker.domain.proof.Proof;
+import com.proofy.proofy_api.checker.domain.sentence.ConSentence;
+import com.proofy.proofy_api.checker.domain.sentence.Sentence;
+import com.proofy.proofy_api.checker.dto.ProofErrorResponse;
+import com.proofy.proofy_api.checker.error.CheckError;
+import com.proofy.proofy_api.checker.error.ProofCheckException;
+import com.proofy.proofy_api.checker.rule.AbstractRule;
+
+import java.util.List;
+
+public class ConE extends AbstractRule {
+
+    @Override
+    public LineNumberType[] lineOrd() {
+        return new LineNumberType[]{ LineNumberType.ONE };
+    }
+
+    @Override
+    public void isRight(Proof proof, Line line, List<ProofErrorResponse> errors) {
+        Sentence source = citedSentence(proof, line, 0);
+
+        if (!(source instanceof ConSentence con))
+            throw new ProofCheckException(CheckError.BAD_USAGE, line.getNumber());
+
+        boolean ok = same(con.getLeft(), line.getSentence()) ||
+                same(con.getRight(), line.getSentence());
+
+        if (!ok) throw new ProofCheckException(CheckError.BAD_USAGE, line.getNumber());
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/rule/impl/ConI.java
+++ b/src/main/java/com/proofy/proofy_api/checker/rule/impl/ConI.java
@@ -1,0 +1,35 @@
+package com.proofy.proofy_api.checker.rule.impl;
+
+import com.proofy.proofy_api.checker.domain.line.LineNumberType;
+import com.proofy.proofy_api.checker.domain.line.Line;
+import com.proofy.proofy_api.checker.domain.proof.Proof;
+import com.proofy.proofy_api.checker.domain.sentence.ConSentence;
+import com.proofy.proofy_api.checker.domain.sentence.Sentence;
+import com.proofy.proofy_api.checker.dto.ProofErrorResponse;
+import com.proofy.proofy_api.checker.error.CheckError;
+import com.proofy.proofy_api.checker.error.ProofCheckException;
+import com.proofy.proofy_api.checker.rule.AbstractRule;
+
+import java.util.List;
+
+public class ConI extends AbstractRule {
+
+    @Override
+    public LineNumberType[] lineOrd() {
+        return new LineNumberType[]{ LineNumberType.ONE, LineNumberType.ONE };
+    }
+
+    @Override
+    public void isRight(Proof proof, Line line, List<ProofErrorResponse> errors) {
+        Sentence sA = citedSentence(proof, line, 0);
+        Sentence sB = citedSentence(proof, line, 1);
+
+        if (!(line.getSentence() instanceof ConSentence con))
+            throw new ProofCheckException(CheckError.BAD_USAGE, line.getNumber());
+
+        boolean ok = (same(con.getLeft(), sA) && same(con.getRight(), sB)) ||
+                (same(con.getLeft(), sB) && same(con.getRight(), sA));
+
+        if (!ok) throw new ProofCheckException(CheckError.BAD_USAGE, line.getNumber());
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/rule/impl/ContraE.java
+++ b/src/main/java/com/proofy/proofy_api/checker/rule/impl/ContraE.java
@@ -1,0 +1,29 @@
+package com.proofy.proofy_api.checker.rule.impl;
+
+import com.proofy.proofy_api.checker.dto.ProofErrorResponse;
+import com.proofy.proofy_api.checker.error.CheckError;
+import com.proofy.proofy_api.checker.domain.line.LineNumberType;
+import com.proofy.proofy_api.checker.domain.line.Line;
+import com.proofy.proofy_api.checker.domain.proof.Proof;
+import com.proofy.proofy_api.checker.error.ProofCheckException;
+import com.proofy.proofy_api.checker.rule.AbstractRule;
+
+import java.util.List;
+
+public class ContraE extends AbstractRule {
+
+    @Override
+    public LineNumberType[] lineOrd() {
+        return new LineNumberType[]{ LineNumberType.ONE };
+    }
+
+    @Override
+    public void isRight(Proof proof, Line line, List<ProofErrorResponse> errors) {
+        var src = citedSentence(proof, line, 0);
+
+        if (!src.isBotSignal())
+            throw new ProofCheckException(CheckError.BAD_USAGE, line.getNumber());
+
+        // ∴ 아무 sentence나 만들어도 OK
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/rule/impl/ContraI.java
+++ b/src/main/java/com/proofy/proofy_api/checker/rule/impl/ContraI.java
@@ -1,0 +1,44 @@
+package com.proofy.proofy_api.checker.rule.impl;
+
+import com.proofy.proofy_api.checker.dto.ProofErrorResponse;
+import com.proofy.proofy_api.checker.error.CheckError;
+import com.proofy.proofy_api.checker.domain.line.LineNumberType;
+import com.proofy.proofy_api.checker.domain.line.Line;
+import com.proofy.proofy_api.checker.domain.proof.Proof;
+import com.proofy.proofy_api.checker.domain.sentence.NegSentence;
+import com.proofy.proofy_api.checker.domain.sentence.Sentence;
+import com.proofy.proofy_api.checker.error.ProofCheckException;
+import com.proofy.proofy_api.checker.rule.AbstractRule;
+
+import java.util.List;
+
+public class ContraI extends AbstractRule {
+
+    @Override
+    public LineNumberType[] lineOrd() {
+        return new LineNumberType[]{
+                LineNumberType.ONE,  // line #1: P
+                LineNumberType.ONE   // line #2: ¬P
+        };
+    }
+
+    @Override
+    public void isRight(Proof proof, Line line, List<ProofErrorResponse> errors) {
+
+        // conclusion must be ⊥
+        if (!line.getSentence().isBotSignal())
+            throw new ProofCheckException(CheckError.BAD_USAGE, line.getNumber());
+
+        // cited sentences
+        Sentence s1 = citedSentence(proof, line, 0);
+        Sentence s2 = citedSentence(proof, line, 1);
+
+        // contradiction requires: one is negation of the other
+        boolean ok =
+                same(s1.negate(), s2) ||
+                        same(s2.negate(), s1);
+
+        if (!ok)
+            throw new ProofCheckException(CheckError.BAD_USAGE, line.getNumber());
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/rule/impl/DisE.java
+++ b/src/main/java/com/proofy/proofy_api/checker/rule/impl/DisE.java
@@ -1,0 +1,57 @@
+package com.proofy.proofy_api.checker.rule.impl;
+
+import com.proofy.proofy_api.checker.domain.sentence.Sentence;
+import com.proofy.proofy_api.checker.dto.ProofErrorResponse;
+import com.proofy.proofy_api.checker.error.CheckError;
+import com.proofy.proofy_api.checker.domain.line.LineNumberType;
+import com.proofy.proofy_api.checker.domain.line.Line;
+import com.proofy.proofy_api.checker.domain.proof.Proof;
+import com.proofy.proofy_api.checker.domain.sentence.DisSentence;
+import com.proofy.proofy_api.checker.error.ProofCheckException;
+import com.proofy.proofy_api.checker.rule.AbstractRule;
+
+import java.util.List;
+
+public class DisE extends AbstractRule {
+
+    @Override
+    public LineNumberType[] lineOrd() {
+        return new LineNumberType[]{
+                LineNumberType.ONE,
+                LineNumberType.MANY,
+                LineNumberType.MANY
+        };
+    }
+
+    @Override
+    public void isRight(Proof proof, Line line, List<ProofErrorResponse> errors) {
+
+        // cited[0] = A ∨ B
+        Sentence dis = citedSentence(proof, line, 0);
+        if (!(dis instanceof DisSentence d))
+            throw new ProofCheckException(CheckError.BAD_USAGE, line.getNumber());
+
+        // cited[1] = subproof A ... C
+        Subproof sp1 = citedSubproof(proof, line, 1, errors);
+        // cited[2] = subproof B ... C
+        Subproof sp2 = citedSubproof(proof, line, 2, errors);
+        if (sp1 == null || sp2 == null) return;
+
+        Sentence p1 = sp1.premise();
+        Sentence c1 = sp1.conclusion();
+        Sentence p2 = sp2.premise();
+        Sentence c2 = sp2.conclusion();
+
+        // 결론 두 개가 같아야 한다
+        if (!same(c1, c2) || !same(c1, line.getSentence()))
+            throw new ProofCheckException(CheckError.BAD_USAGE, line.getNumber());
+
+        // (A == p1 && B == p2) or (A == p2 && B == p1)
+        boolean ok =
+                (same(d.getLeft(), p1) && same(d.getRight(), p2)) ||
+                        (same(d.getLeft(), p2) && same(d.getRight(), p1));
+
+        if (!ok)
+            throw new ProofCheckException(CheckError.BAD_USAGE, line.getNumber());
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/rule/impl/DisI.java
+++ b/src/main/java/com/proofy/proofy_api/checker/rule/impl/DisI.java
@@ -1,0 +1,33 @@
+package com.proofy.proofy_api.checker.rule.impl;
+
+import com.proofy.proofy_api.checker.domain.line.LineNumberType;
+import com.proofy.proofy_api.checker.domain.line.Line;
+import com.proofy.proofy_api.checker.domain.proof.Proof;
+import com.proofy.proofy_api.checker.domain.sentence.DisSentence;
+import com.proofy.proofy_api.checker.domain.sentence.Sentence;
+import com.proofy.proofy_api.checker.dto.ProofErrorResponse;
+import com.proofy.proofy_api.checker.error.CheckError;
+import com.proofy.proofy_api.checker.error.ProofCheckException;
+import com.proofy.proofy_api.checker.rule.AbstractRule;
+
+import java.util.List;
+
+public class DisI extends AbstractRule {
+
+    @Override
+    public LineNumberType[] lineOrd() {
+        return new LineNumberType[]{ LineNumberType.ONE };
+    }
+
+    @Override
+    public void isRight(Proof proof, Line line, List<ProofErrorResponse> errors) {
+        Sentence src = citedSentence(proof, line, 0);
+        Sentence tgt = line.getSentence();
+
+        if (!(tgt instanceof DisSentence dis))
+            throw new ProofCheckException(CheckError.BAD_USAGE, line.getNumber());
+
+        if (!(same(dis.getLeft(), src) || same(dis.getRight(), src)))
+            throw new ProofCheckException(CheckError.BAD_USAGE, line.getNumber());
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/rule/impl/ImpE.java
+++ b/src/main/java/com/proofy/proofy_api/checker/rule/impl/ImpE.java
@@ -1,0 +1,47 @@
+package com.proofy.proofy_api.checker.rule.impl;
+
+import com.proofy.proofy_api.checker.dto.ProofErrorResponse;
+import com.proofy.proofy_api.checker.error.CheckError;
+import com.proofy.proofy_api.checker.domain.line.LineNumberType;
+import com.proofy.proofy_api.checker.domain.line.Line;
+import com.proofy.proofy_api.checker.domain.proof.Proof;
+import com.proofy.proofy_api.checker.domain.sentence.ImpSentence;
+import com.proofy.proofy_api.checker.domain.sentence.Sentence;
+import com.proofy.proofy_api.checker.error.ProofCheckException;
+import com.proofy.proofy_api.checker.rule.AbstractRule;
+
+import java.util.List;
+
+public class ImpE extends AbstractRule {
+
+    @Override
+    public LineNumberType[] lineOrd() {
+        return new LineNumberType[]{
+                LineNumberType.ONE,
+                LineNumberType.ONE
+        };
+    }
+
+    @Override
+    public void isRight(Proof proof, Line line, List<ProofErrorResponse> errors) {
+        Sentence s1 = citedSentence(proof, line, 0);
+        Sentence s2 = citedSentence(proof, line, 1);
+        Sentence tgt = line.getSentence();
+
+        // Case 1: s1 = A → B, s2 = A, tgt = B
+        if (s1 instanceof ImpSentence imp1) {
+            if (same(imp1.getLeft(), s2) && same(imp1.getRight(), tgt)) {
+                return;
+            }
+        }
+
+        // Case 2: s2 = A → B, s1 = A, tgt = B
+        if (s2 instanceof ImpSentence imp2) {
+            if (same(imp2.getLeft(), s1) && same(imp2.getRight(), tgt)) {
+                return;
+            }
+        }
+
+        throw new ProofCheckException(CheckError.BAD_USAGE, line.getNumber());
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/rule/impl/ImpI.java
+++ b/src/main/java/com/proofy/proofy_api/checker/rule/impl/ImpI.java
@@ -1,0 +1,34 @@
+package com.proofy.proofy_api.checker.rule.impl;
+
+import com.proofy.proofy_api.checker.dto.ProofErrorResponse;
+import com.proofy.proofy_api.checker.error.CheckError;
+import com.proofy.proofy_api.checker.domain.line.LineNumberType;
+import com.proofy.proofy_api.checker.domain.line.Line;
+import com.proofy.proofy_api.checker.domain.proof.Proof;
+import com.proofy.proofy_api.checker.domain.sentence.ImpSentence;
+import com.proofy.proofy_api.checker.error.ProofCheckException;
+import com.proofy.proofy_api.checker.rule.AbstractRule;
+
+import java.util.List;
+
+public class ImpI extends AbstractRule {
+
+    @Override
+    public LineNumberType[] lineOrd() {
+        return new LineNumberType[]{ LineNumberType.MANY };
+    }
+
+    @Override
+    public void isRight(Proof proof, Line line, List<ProofErrorResponse> errors) {
+        Subproof sp = citedSubproof(proof, line, 0, errors);
+        if (sp == null) return;
+
+        if (!(line.getSentence() instanceof ImpSentence imp))
+            throw new ProofCheckException(CheckError.BAD_USAGE, line.getNumber());
+
+        // sp.premise = A, sp.conclusion = B
+        if (!(same(imp.getLeft(), sp.premise()) &&
+                same(imp.getRight(), sp.conclusion())))
+            throw new ProofCheckException(CheckError.BAD_USAGE, line.getNumber());
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/rule/impl/NegE.java
+++ b/src/main/java/com/proofy/proofy_api/checker/rule/impl/NegE.java
@@ -1,0 +1,63 @@
+package com.proofy.proofy_api.checker.rule.impl;
+
+import com.proofy.proofy_api.checker.domain.sentence.NegSentence;
+import com.proofy.proofy_api.checker.dto.ProofErrorResponse;
+import com.proofy.proofy_api.checker.error.CheckError;
+import com.proofy.proofy_api.checker.domain.line.LineNumberType;
+import com.proofy.proofy_api.checker.domain.line.Line;
+import com.proofy.proofy_api.checker.domain.proof.Proof;
+import com.proofy.proofy_api.checker.domain.sentence.Sentence;
+import com.proofy.proofy_api.checker.error.ProofCheckException;
+import com.proofy.proofy_api.checker.rule.AbstractRule;
+
+import java.util.List;
+
+public class NegE extends AbstractRule {
+
+    @Override
+    public LineNumberType[] lineOrd() {
+        return new LineNumberType[]{ LineNumberType.ONE };
+    }
+
+    @Override
+    public void isRight(Proof proof, Line line, List<ProofErrorResponse> errors) {
+
+        Sentence premise = citedSentence(proof, line, 0);
+
+        // premise 전체에서 부정(~ or ¬) 반복적으로 제거
+        Sentence inner = stripDoubleNegations(premise);
+
+        // 결론은 strip된 inner와 동일해야 함
+        if (!same(inner, line.getSentence())) {
+            throw new ProofCheckException(CheckError.BAD_USAGE, line.getNumber());
+        }
+    }
+
+    /**
+     * ¬¬¬¬P → P
+     * ¬¬¬¬¬¬Q → Q
+     * 짝수 개의 부정이면 모두 제거.
+     */
+    private Sentence stripDoubleNegations(Sentence s) {
+        Sentence curr = s;
+        int count = 0;
+
+        // negs count
+        while (curr instanceof NegSentence neg) {
+            curr = neg.inner();
+            count++;
+        }
+
+        // 부정이 짝수면 다 제거
+        if (count % 2 == 0) {
+            return curr;
+        }
+
+        // 홀수 부정이면 마지막 하나는 남겨야 함 → ¬(inner)
+        Sentence result = curr;
+        for (int i = 0; i < count % 2; i++) {
+            result = new NegSentence(result);
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/rule/impl/NegI.java
+++ b/src/main/java/com/proofy/proofy_api/checker/rule/impl/NegI.java
@@ -1,0 +1,78 @@
+package com.proofy.proofy_api.checker.rule.impl;
+
+import com.proofy.proofy_api.checker.dto.ProofErrorResponse;
+import com.proofy.proofy_api.checker.error.CheckError;
+import com.proofy.proofy_api.checker.domain.line.LineNumberType;
+import com.proofy.proofy_api.checker.domain.line.Line;
+import com.proofy.proofy_api.checker.domain.proof.Proof;
+import com.proofy.proofy_api.checker.domain.sentence.NegSentence;
+import com.proofy.proofy_api.checker.domain.sentence.Sentence;
+import com.proofy.proofy_api.checker.error.ProofCheckException;
+import com.proofy.proofy_api.checker.rule.AbstractRule;
+
+import java.util.List;
+
+public class NegI extends AbstractRule {
+
+    @Override
+    public LineNumberType[] lineOrd() {
+        return new LineNumberType[]{ LineNumberType.MANY };
+    }
+
+    @Override
+    public void isRight(Proof proof, Line line, List<ProofErrorResponse> errors) {
+
+        // subproof range
+        Subproof sp = citedSubproof(proof, line, 0, errors);
+        if (sp == null) return;
+
+        Sentence premise = sp.premise();       // A or ¬A
+        Sentence conclusion = sp.conclusion(); // must be ⊥
+
+        // subproof 마지막은 ⊥이어야 함
+        if (!conclusion.isBotSignal()) {
+            throw new ProofCheckException(CheckError.BAD_USAGE, line.getNumber());
+        }
+
+        // ★ 결론 문장을 가져온다 (line.getSentence())
+        Sentence result = line.getSentence();
+
+        // ★ 결론 문장이 부정인지 검사
+        //    BUT: 교재식 4줄 요약을 허용하기 위해
+        //    - result가 NegSentence면 그대로 사용
+        //    - result가 AtomSentence면 자동으로 ¬를 붙이고 다시 비교
+        Sentence strippedConclusion = stripDoubleNegations(result);
+
+        // ★ premise가 A 라면, neg(inner) = ¬A 여야 함
+        // ★ premise가 ¬A 라면, neg(inner) = ¬¬A 여야 함 -> NegE에 의해 A로 줄어들 수도 있음
+        Sentence expected = new NegSentence(premise);
+
+        // expected도 strip
+        Sentence strippedExpected = stripDoubleNegations(expected);
+
+        // 비교
+        if (!same(strippedConclusion, strippedExpected)) {
+            throw new ProofCheckException(CheckError.BAD_USAGE, line.getNumber());
+        }
+    }
+
+    /**
+     * NegE와 동일한 로직: 짝수개의 부정은 모두 제거하고, 홀수개면 하나만 남김.
+     */
+    private Sentence stripDoubleNegations(Sentence s) {
+        Sentence curr = s;
+        int count = 0;
+
+        while (curr instanceof NegSentence neg) {
+            curr = neg.inner();
+            count++;
+        }
+
+        if (count % 2 == 0) {
+            return curr; // completely removed
+        }
+
+        // odd → leave one neg
+        return new NegSentence(curr);
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/rule/impl/PR.java
+++ b/src/main/java/com/proofy/proofy_api/checker/rule/impl/PR.java
@@ -1,0 +1,21 @@
+package com.proofy.proofy_api.checker.rule.impl;
+
+import com.proofy.proofy_api.checker.domain.line.Line;
+import com.proofy.proofy_api.checker.domain.line.LineNumberType;
+import com.proofy.proofy_api.checker.domain.proof.Proof;
+import com.proofy.proofy_api.checker.dto.ProofErrorResponse;
+import com.proofy.proofy_api.checker.rule.AbstractRule;
+
+import java.util.List;
+
+public class PR extends AbstractRule {
+    @Override
+    public LineNumberType[] lineOrd() {
+        return new LineNumberType[]{};
+    }
+
+    @Override
+    public void isRight(Proof proof, Line line, List<ProofErrorResponse> errors) {
+        // 항상 OKAY
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/rule/impl/R.java
+++ b/src/main/java/com/proofy/proofy_api/checker/rule/impl/R.java
@@ -1,0 +1,30 @@
+package com.proofy.proofy_api.checker.rule.impl;
+
+import com.proofy.proofy_api.checker.domain.line.LineNumberType;
+import com.proofy.proofy_api.checker.domain.line.Line;
+import com.proofy.proofy_api.checker.domain.proof.Proof;
+import com.proofy.proofy_api.checker.dto.ProofErrorResponse;
+import com.proofy.proofy_api.checker.error.CheckError;
+import com.proofy.proofy_api.checker.error.ProofCheckException;
+import com.proofy.proofy_api.checker.rule.AbstractRule;
+
+import java.util.List;
+
+public class R extends AbstractRule {
+
+    @Override
+    public LineNumberType[] lineOrd() {
+        return new LineNumberType[]{ LineNumberType.ONE };
+    }
+
+    @Override
+    public void isRight(Proof proof, Line line, List<ProofErrorResponse> errors) {
+        var source = citedSentence(proof, line, 0);
+
+        if (!same(source, line.getSentence())) {
+            throw new ProofCheckException(
+                    CheckError.BAD_USAGE, line.getNumber()
+            );
+        }
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/service/CheckerService.java
+++ b/src/main/java/com/proofy/proofy_api/checker/service/CheckerService.java
@@ -1,0 +1,107 @@
+package com.proofy.proofy_api.checker.service;
+
+import com.proofy.proofy_api.checker.checker.ProofChecker;
+import com.proofy.proofy_api.checker.domain.line.Line;
+import com.proofy.proofy_api.checker.domain.proof.Proof;
+import com.proofy.proofy_api.checker.domain.sentence.Sentence;
+import com.proofy.proofy_api.checker.dto.ProofCheckRequest;
+import com.proofy.proofy_api.checker.dto.ProofErrorResponse;
+import com.proofy.proofy_api.checker.error.CheckError;
+import com.proofy.proofy_api.checker.error.ProofCheckException;
+import com.proofy.proofy_api.checker.error.ProofParseException;
+import com.proofy.proofy_api.checker.parser.CitationParser;
+import com.proofy.proofy_api.checker.parser.SentenceParser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class CheckerService {
+
+    private final ProofChecker proofChecker;
+    private final CitationParser citationParser;
+    private final SentenceParser sentenceParser;
+
+    public List<ProofErrorResponse> checkProof(ProofCheckRequest request) {
+        List<ProofErrorResponse> errors = new ArrayList<>();
+
+        // 1) 요청을 Proof 도메인으로 변환
+        List<Line> lines = request.lines().stream()
+                .map(req -> {
+                    try {
+                        return new Line(
+                                req.number(),
+                                req.depth(),
+                                sentenceParser.parse(req.sentence(), req.number()),
+                                citationParser.parse(req.citation(), req.number())
+                        );
+                    } catch (ProofParseException e) {
+                        errors.add(new ProofErrorResponse(
+                                e.getOriginLine(),
+                                e.getError().name(),
+                                "문장, 인용 검사 중 파싱에 실패했습니다."
+                        ));
+                        return Line.invalid(req.number(), req.depth());
+                    }
+                })
+                .toList();
+        Proof proof = new Proof(lines);
+
+        // 2) premise와 conclusion이 맞는지 확인
+        List<Sentence> premises = request.premises().stream()
+                .map(premiseString -> sentenceParser.parse(premiseString, 0))
+                .toList();
+        String conclusion = sentenceParser.parse(request.conclusion(), 0).toString();
+        List<Line> proofLines = proof.getLines();   // Proof(lines) 내부에서 파싱된 라인
+
+        // premise 개수 검증
+        if (proofLines.size() < premises.size() + 1) // 제공된 증명 < 전제 + 결론 개수
+            errors.add(new ProofErrorResponse(0, "INVALID_PROOF_STRUCTURE", "충분한 Line을 작성하지 않았습니다."));
+
+        // ----- Premise 검증 -----
+        for (int i = 0; i < premises.size(); i++) {
+            Line line = proofLines.get(i);
+
+            // 파싱 실패한 줄이면 premise mismatch 체크 생략
+            if (line.isInvalid()) continue;
+
+            String expected = premises.get(i).toString();
+            String actual = line.getSentence().toString();
+
+            if (!expected.equals(actual))
+                errors.add(new ProofErrorResponse(line.getNumber(),
+                        "PREMISE_MISMATCH",
+                        String.format("Premise %d가 문제의 premise와 일치하지 않습니다. expected=%s, actual=%s",
+                                i + 1, expected, actual)));
+        }
+
+        // ----- Conclusion 검증 -----
+        Line actualConclusion = proofLines.get(proofLines.size() - 1);
+
+        // 1) 결론 줄 자체가 invalid → conclusion mismatch 검사 skip
+        if (actualConclusion.isInvalid()) {
+            // 결론 parse error는 이미 파싱 단계에서 errors 리스트에 들어간 상태.
+            // 여기서 중복 에러 찍지 않음.
+            return errors;
+        }
+
+        String actualConclusionSentence = actualConclusion.getSentence().toString();
+
+        if (!conclusion.equals(actualConclusionSentence)) {
+            errors.add(new ProofErrorResponse(
+                    actualConclusion.getNumber(),
+                    "CONCLUSION_MISMATCH",
+                    String.format("결론이 문제에서 요구한 conclusion과 다릅니다. expected=%s, actual=%s",
+                            conclusion, actualConclusionSentence)
+            ));
+        }
+
+        // 2) ProofChecker 실행
+        errors.addAll(proofChecker.check(proof));  // ← 성공 시 예외 없음
+        return errors;
+    }
+}

--- a/src/main/java/com/proofy/proofy_api/checker/testJSON/Lec6-02.JSON
+++ b/src/main/java/com/proofy/proofy_api/checker/testJSON/Lec6-02.JSON
@@ -1,0 +1,80 @@
+{
+  "premises": [
+    "(A ∨ B) ∨ C"
+  ],
+  "conclusion": "A ∨ (B ∨ C)",
+  "lines": [
+    {
+      "number": 1,
+      "depth": 0,
+      "sentence": "(A ∨ B) ∨ C",
+      "citation": "PR"
+    },
+    {
+      "number": 2,
+      "depth": 1,
+      "sentence": "A ∨ B",
+      "citation": "PR"
+    },
+    {
+      "number": 3,
+      "depth": 2,
+      "sentence": "A",
+      "citation": "PR"
+    },
+    {
+      "number": 4,
+      "depth": 2,
+      "sentence": "A ∨ (B ∨ C)",
+      "citation": "∨I 3"
+    },
+    {
+      "number": 5,
+      "depth": 2,
+      "sentence": "B",
+      "citation": "PR"
+    },
+    {
+      "number": 6,
+      "depth": 2,
+      "sentence": "B ∨ C",
+      "citation": "∨I 5"
+    },
+    {
+      "number": 7,
+      "depth": 2,
+      "sentence": "A ∨ (B ∨ C)",
+      "citation": "∨I 6"
+    },
+    {
+      "number": 8,
+      "depth": 1,
+      "sentence": "A ∨ (B ∨ C)",
+      "citation": "∨E 2 3-4 5-7"
+    },
+    {
+      "number": 9,
+      "depth": 1,
+      "sentence": "C",
+      "citation": "PR"
+    },
+    {
+      "number": 10,
+      "depth": 1,
+      "sentence": "B ∨ C",
+      "citation": "∨I 9"
+    },
+    {
+      "number": 11,
+      "depth": 1,
+      "sentence": "A ∨ (B ∨ C)",
+      "citation": "∨I 10"
+    },
+    {
+      "number": 12,
+      "depth": 0,
+      "sentence": "A ∨ (B ∨ C)",
+      "citation": "∨E 1 2-8 9-11"
+    }
+  ]
+}

--- a/src/main/java/com/proofy/proofy_api/checker/testJSON/Lec6-07.JSON
+++ b/src/main/java/com/proofy/proofy_api/checker/testJSON/Lec6-07.JSON
@@ -1,0 +1,50 @@
+{
+  "premises": [
+    "(A ∧ B) ∨ C"
+  ],
+  "conclusion": "C ∨ B",
+  "lines": [
+    {
+      "number": 1,
+      "depth": 0,
+      "sentence": "(A ∧ B) ∨ C",
+      "citation": "PR"
+    },
+    {
+      "number": 2,
+      "depth": 1,
+      "sentence": "A ∧ B",
+      "citation": "PR"
+    },
+    {
+      "number": 3,
+      "depth": 1,
+      "sentence": "B",
+      "citation": "∧E 2"
+    },
+    {
+      "number": 4,
+      "depth": 1,
+      "sentence": "C ∨ B",
+      "citation": "∨I 3"
+    },
+    {
+      "number": 5,
+      "depth": 1,
+      "sentence": "C",
+      "citation": "PR"
+    },
+    {
+      "number": 6,
+      "depth": 1,
+      "sentence": "C ∨ B",
+      "citation": "∨I 5"
+    },
+    {
+      "number": 7,
+      "depth": 0,
+      "sentence": "C ∨ B",
+      "citation": "∨E 1 2-4 5-6"
+    }
+  ]
+}

--- a/src/main/java/com/proofy/proofy_api/checker/testJSON/Lec7-01.JSON
+++ b/src/main/java/com/proofy/proofy_api/checker/testJSON/Lec7-01.JSON
@@ -1,0 +1,42 @@
+{
+  "premises": [
+    "¬(A ∨ B)"
+  ],
+  "conclusion": "¬A",
+  "lines": [
+    {
+      "number": 1,
+      "depth": 0,
+      "sentence": "¬(A ∨ B)",
+      "citation": "PR"
+    },
+
+    {
+      "number": 2,
+      "depth": 1,
+      "sentence": "A",
+      "citation": "PR"
+    },
+
+    {
+      "number": 3,
+      "depth": 1,
+      "sentence": "A ∨ B",
+      "citation": "∨I 2"
+    },
+
+    {
+      "number": 4,
+      "depth": 1,
+      "sentence": "⊥",
+      "citation": "⊥I 1 3"
+    },
+
+    {
+      "number": 5,
+      "depth": 0,
+      "sentence": "¬A",
+      "citation": "¬I 2-4"
+    }
+  ]
+}

--- a/src/main/java/com/proofy/proofy_api/checker/testJSON/Lec7-03.JSON
+++ b/src/main/java/com/proofy/proofy_api/checker/testJSON/Lec7-03.JSON
@@ -1,0 +1,62 @@
+{
+  "premises": [
+    "A ∧ (B ∨ C)"
+  ],
+  "conclusion": "(A ∧ B) ∨ (A ∧ C)",
+  "lines": [
+    {
+      "number": 1,
+      "depth": 0,
+      "sentence": "A ∧ (B ∨ C)",
+      "citation": "PR"
+    },
+
+    { "number": 2, "depth": 0, "sentence": "A", "citation": "∧E 1" },
+    { "number": 3, "depth": 0, "sentence": "B ∨ C", "citation": "∧E 1" },
+
+    {
+      "number": 4,
+      "depth": 1,
+      "sentence": "B",
+      "citation": "PR"
+    },
+    {
+      "number": 5,
+      "depth": 1,
+      "sentence": "A ∧ B",
+      "citation": "∧I 2 4"
+    },
+    {
+      "number": 6,
+      "depth": 1,
+      "sentence": "(A ∧ B) ∨ (A ∧ C)",
+      "citation": "∨I 5"
+    },
+
+    {
+      "number": 7,
+      "depth": 1,
+      "sentence": "C",
+      "citation": "PR"
+    },
+    {
+      "number": 8,
+      "depth": 1,
+      "sentence": "A ∧ C",
+      "citation": "∧I 2 7"
+    },
+    {
+      "number": 9,
+      "depth": 1,
+      "sentence": "(A ∧ B) ∨ (A ∧ C)",
+      "citation": "∨I 8"
+    },
+
+    {
+      "number": 10,
+      "depth": 0,
+      "sentence": "(A ∧ B) ∨ (A ∧ C)",
+      "citation": "∨E 3 4-6 7-9"
+    }
+  ]
+}

--- a/src/main/java/com/proofy/proofy_api/checker/testJSON/Lec7-04.JSON
+++ b/src/main/java/com/proofy/proofy_api/checker/testJSON/Lec7-04.JSON
@@ -1,0 +1,68 @@
+{
+  "premises": [
+    "¬(A ∨ B)"
+  ],
+  "conclusion": "¬A ∧ ¬B",
+  "lines": [
+    {
+      "number": 1,
+      "depth": 0,
+      "sentence": "¬(A ∨ B)",
+      "citation": "PR"
+    },
+    {
+      "number": 2,
+      "depth": 1,
+      "sentence": "A",
+      "citation": "PR"
+    },
+    {
+      "number": 3,
+      "depth": 1,
+      "sentence": "A ∨ B",
+      "citation": "∨I 2"
+    },
+    {
+      "number": 4,
+      "depth": 1,
+      "sentence": "⊥",
+      "citation": "⊥I 1 3"
+    },
+    {
+      "number": 5,
+      "depth": 0,
+      "sentence": "¬A",
+      "citation": "¬I 2-4"
+    },
+    {
+      "number": 6,
+      "depth": 1,
+      "sentence": "B",
+      "citation": "PR"
+    },
+    {
+      "number": 7,
+      "depth": 1,
+      "sentence": "A ∨ B",
+      "citation": "∨I 6"
+    },
+    {
+      "number": 8,
+      "depth": 1,
+      "sentence": "⊥",
+      "citation": "⊥I 1 7"
+    },
+    {
+      "number": 9,
+      "depth": 0,
+      "sentence": "¬B",
+      "citation": "¬I 6-8"
+    },
+    {
+      "number": 10,
+      "depth": 0,
+      "sentence": "¬A ∧ ¬B",
+      "citation": "∧I 5 9"
+    }
+  ]
+}

--- a/src/main/java/com/proofy/proofy_api/checker/testJSON/Lec7-05.JSON
+++ b/src/main/java/com/proofy/proofy_api/checker/testJSON/Lec7-05.JSON
@@ -1,0 +1,92 @@
+{
+  "premises": [ "¬(A ∧ B)" ], "conclusion": "¬A ∨ ¬B",
+  "lines": [
+    {
+      "number": 1,
+      "depth": 0,
+      "sentence": "¬(A ∧ B)",
+      "citation": "PR"
+    },
+
+    {
+      "number": 2,
+      "depth": 1,
+      "sentence": "¬(¬A ∨ ¬B)",
+      "citation": "PR"
+    },
+
+    {
+      "number": 3,
+      "depth": 2,
+      "sentence": "A",
+      "citation": "PR"
+    },
+
+    {
+      "number": 4,
+      "depth": 3,
+      "sentence": "B",
+      "citation": "PR"
+    },
+
+    {
+      "number": 5,
+      "depth": 3,
+      "sentence": "A ∧ B",
+      "citation": "∧I 3 4"
+    },
+
+    {
+      "number": 6,
+      "depth": 3,
+      "sentence": "⊥",
+      "citation": "⊥I 1 5"
+    },
+
+    {
+      "number": 7,
+      "depth": 2,
+      "sentence": "¬B",
+      "citation": "¬I 4-6"
+    },
+
+    {
+      "number": 8,
+      "depth": 2,
+      "sentence": "¬A ∨ ¬B",
+      "citation": "∨I 7"
+    },
+
+    {
+      "number": 9,
+      "depth": 2,
+      "sentence": "⊥",
+      "citation": "⊥I 2 8"
+    },
+
+    {
+      "number": 10,
+      "depth": 1,
+      "sentence": "¬A",
+      "citation": "¬I 3-9"
+    },
+    {
+      "number": 11,
+      "depth": 1,
+      "sentence": "¬A ∨ ¬B",
+      "citation": "∨I 10"
+    },
+    {
+      "number": 12,
+      "depth": 1,
+      "sentence": "⊥",
+      "citation": "⊥I 2 11"
+    },
+    {
+      "number": 13,
+      "depth": 0,
+      "sentence": "¬A ∨ ¬B",
+      "citation": "¬I 2-12"
+    }
+  ]
+}

--- a/src/main/java/com/proofy/proofy_api/checker/testJSON/Lec7-06.JSON
+++ b/src/main/java/com/proofy/proofy_api/checker/testJSON/Lec7-06.JSON
@@ -1,0 +1,104 @@
+{
+  "premises": [
+    "(A ∧ ¬B) ∨ (C ∨ D)",
+    "¬C ∧ B"
+  ],
+  "conclusion": "¬¬D",
+  "lines": [
+    {
+      "number": 1,
+      "depth": 0,
+      "sentence": "(A ∧ ¬B) ∨ (C ∨ D)",
+      "citation": "PR"
+    },
+    {
+      "number": 2,
+      "depth": 0,
+      "sentence": "¬C ∧ B",
+      "citation": "PR"
+    },
+
+    { "number": 3, "depth": 0, "sentence": "¬C", "citation": "∧E 2" },
+    { "number": 4, "depth": 0, "sentence": "B", "citation": "∧E 2" },
+
+    {
+      "number": 5,
+      "depth": 1,
+      "sentence": "¬D",
+      "citation": "PR"
+    },
+
+    {
+      "number": 6,
+      "depth": 2,
+      "sentence": "A ∧ ¬B",
+      "citation": "PR"
+    },
+    {
+      "number": 7,
+      "depth": 2,
+      "sentence": "¬B",
+      "citation": "∧E 6"
+    },
+    {
+      "number": 8,
+      "depth": 2,
+      "sentence": "⊥",
+      "citation": "⊥I 4 7"
+    },
+
+    {
+      "number": 9,
+      "depth": 2,
+      "sentence": "C ∨ D",
+      "citation": "PR"
+    },
+
+    {
+      "number": 10,
+      "depth": 3,
+      "sentence": "C",
+      "citation": "PR"
+    },
+    {
+      "number": 11,
+      "depth": 3,
+      "sentence": "⊥",
+      "citation": "⊥I 3 10"
+    },
+
+    {
+      "number": 12,
+      "depth": 3,
+      "sentence": "D",
+      "citation": "PR"
+    },
+    {
+      "number": 13,
+      "depth": 3,
+      "sentence": "⊥",
+      "citation": "⊥I 5 12"
+    },
+
+    {
+      "number": 14,
+      "depth": 2,
+      "sentence": "⊥",
+      "citation": "∨E 9 10-11 12-13"
+    },
+
+    {
+      "number": 15,
+      "depth": 1,
+      "sentence": "⊥",
+      "citation": "∨E 1 6-8 9-14"
+    },
+
+    {
+      "number": 16,
+      "depth": 0,
+      "sentence": "¬¬D",
+      "citation": "¬I 5-15"
+    }
+  ]
+}

--- a/src/main/java/com/proofy/proofy_api/checker/testJSON/Lec7-P01.JSON
+++ b/src/main/java/com/proofy/proofy_api/checker/testJSON/Lec7-P01.JSON
@@ -1,0 +1,32 @@
+{
+  "premises": [
+    "A"
+  ],
+  "conclusion": "¬¬A",
+  "lines": [
+    {
+      "number": 1,
+      "depth": 0,
+      "sentence": "A",
+      "citation": "PR"
+    },
+    {
+      "number": 2,
+      "depth": 1,
+      "sentence": "¬A",
+      "citation": "PR"
+    },
+    {
+      "number": 3,
+      "depth": 1,
+      "sentence": "⊥",
+      "citation": "⊥I 1 2"
+    },
+    {
+      "number": 4,
+      "depth": 0,
+      "sentence": "¬¬A",
+      "citation": "¬I 2-3"
+    }
+  ]
+}

--- a/src/main/java/com/proofy/proofy_api/checker/testJSON/Lec7-P02.JSON
+++ b/src/main/java/com/proofy/proofy_api/checker/testJSON/Lec7-P02.JSON
@@ -1,0 +1,60 @@
+{
+  "premises": [
+    "P ∨ Q",
+    "¬Q"
+  ],
+  "conclusion": "P",
+  "lines": [
+    {
+      "number": 1,
+      "depth": 0,
+      "sentence": "P ∨ Q",
+      "citation": "PR"
+    },
+    {
+      "number": 2,
+      "depth": 0,
+      "sentence": "¬Q",
+      "citation": "PR"
+    },
+
+    {
+      "number": 3,
+      "depth": 1,
+      "sentence": "P",
+      "citation": "PR"
+    },
+    {
+      "number": 4,
+      "depth": 1,
+      "sentence": "P",
+      "citation": "R 3"
+    },
+
+    {
+      "number": 5,
+      "depth": 1,
+      "sentence": "Q",
+      "citation": "PR"
+    },
+    {
+      "number": 6,
+      "depth": 1,
+      "sentence": "⊥",
+      "citation": "⊥I 2 5"
+    },
+    {
+      "number": 7,
+      "depth": 1,
+      "sentence": "P",
+      "citation": "⊥E 6"
+    },
+
+    {
+      "number": 8,
+      "depth": 0,
+      "sentence": "P",
+      "citation": "∨E 1 3-4 5-7"
+    }
+  ]
+}

--- a/src/main/java/com/proofy/proofy_api/checker/testJSON/Lec7-P03.JSON
+++ b/src/main/java/com/proofy/proofy_api/checker/testJSON/Lec7-P03.JSON
@@ -1,0 +1,15 @@
+{
+  "premises": [
+    "A"
+  ],
+  "conclusion": "A",
+  "lines": [
+    { "number": 1, "depth": 0, "sentence": "A", "citation": "PR" },
+
+    { "number": 2, "depth": 1, "sentence": "¬A", "citation": "PR" },
+    { "number": 3, "depth": 1, "sentence": "⊥", "citation": "⊥I 1 2" },
+
+    { "number": 4, "depth": 0, "sentence": "¬¬A", "citation": "¬I 2-3" },
+    { "number": 5, "depth": 0, "sentence": "A", "citation": "¬E 4" }
+  ]
+}

--- a/src/main/java/com/proofy/proofy_api/checker/testJSON/Lec7-P04.JSON
+++ b/src/main/java/com/proofy/proofy_api/checker/testJSON/Lec7-P04.JSON
@@ -1,0 +1,32 @@
+{
+  "premises": [
+    "A"
+  ],
+  "conclusion": "A",
+  "lines": [
+    {
+      "number": 1,
+      "depth": 0,
+      "sentence": "A",
+      "citation": "PR"
+    },
+    {
+      "number": 2,
+      "depth": 1,
+      "sentence": "¬A",
+      "citation": "PR"
+    },
+    {
+      "number": 3,
+      "depth": 1,
+      "sentence": "⊥",
+      "citation": "⊥I 1 2"
+    },
+    {
+      "number": 4,
+      "depth": 0,
+      "sentence": "A",
+      "citation": "¬I 2-3"
+    }
+  ]
+}

--- a/src/main/java/com/proofy/proofy_api/checker/testJSON/Lec7-P05.JSON
+++ b/src/main/java/com/proofy/proofy_api/checker/testJSON/Lec7-P05.JSON
@@ -1,0 +1,68 @@
+{
+  "premises": [
+    "¬A ∧ ¬B"
+  ],
+  "conclusion": "¬(A ∨ B)",
+  "lines": [
+    {
+      "number": 1,
+      "depth": 0,
+      "sentence": "¬A ∧ ¬B",
+      "citation": "PR"
+    },
+    {
+      "number": 2,
+      "depth": 0,
+      "sentence": "¬A",
+      "citation": "∧E 1"
+    },
+    {
+      "number": 3,
+      "depth": 0,
+      "sentence": "¬B",
+      "citation": "∧E 1"
+    },
+    {
+      "number": 4,
+      "depth": 1,
+      "sentence": "A ∨ B",
+      "citation": "PR"
+    },
+    {
+      "number": 5,
+      "depth": 2,
+      "sentence": "A",
+      "citation": "PR"
+    },
+    {
+      "number": 6,
+      "depth": 2,
+      "sentence": "⊥",
+      "citation": "⊥I 2 5"
+    },
+    {
+      "number": 7,
+      "depth": 2,
+      "sentence": "B",
+      "citation": "PR"
+    },
+    {
+      "number": 8,
+      "depth": 2,
+      "sentence": "⊥",
+      "citation": "⊥I 3 7"
+    },
+    {
+      "number": 9,
+      "depth": 1,
+      "sentence": "⊥",
+      "citation": "∨E 4 5-6 7-8"
+    },
+    {
+      "number": 10,
+      "depth": 0,
+      "sentence": "¬(A ∨ B)",
+      "citation": "¬I 4-9"
+    }
+  ]
+}


### PR DESCRIPTION
## 🔍 요약
자연연역 기반 형식증명 채점 기능을 구현하기 위한 전체 모듈을 1차적으로 완성했습니다.  
도메인 정의 → 파싱 모듈 → 규칙 세트 정의 → RuleRepository → 시그니처 검증 → 실제 의미 검증 → 서비스/컨트롤러  
까지 end-to-end 로직이 동작하며 `/api/checker/check` 엔드포인트를 통해 채점 결과를 반환합니다.

---

## ✨ 작업 내용
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 테스트 코드 작성

### 상세 내용
- **도메인 모델 정의(Line, Citation, Sentence 등)**  
  - DB 저장과 무관한 채점 전용 순수 도메인 구조 설정
  - invalid line 지원을 통해 parsing 실패 라인도 구조 검증 가능하도록 설계

- **기본 Rule 클래스 14종 구현**  
  - ∧I, ∧E, ∨I, ∨E, →I, →E, ↔I, ↔E, ¬I, ¬E, ⊥I, ⊥E, PR, R  
  - 각 Rule에 대해 `lineOrd()`로 operand 개수/타입(ONE/MANY) 정의

- **BasicRuleSet / RuleRepository 구성**  
  - 모든 자연연역 규칙을 중앙에서 관리
  - 규칙 조회 및 ruleName 유효성 검사 지원

- **SentenceParser / CitationParser 구현**  
  - raw String 기반 문장/인용 파싱
  - LineNumber(ONE/RANGE) 구조 생성

- **ProofChecker 구현 (핵심)**  
  - 구조 검증(validateStructure)
  - Line number 증가 검증
  - depth/subproof 구조 검증  
  - 규칙 시그니처(lineOrd 기반 operand 개수/타입 체크)
  - 규칙 실제 의미 검증(rule.isRight)

- **에러 모듈 구성(Error ENUM / Exception)**  
  - BAD_LINE, BAD_RANGE, BAD_USAGE, BAD_LINE_TYPE, BAD_LINE_COUNT 등 정의
  - 파싱 및 채점 과정에서 통합적으로 반환

- **Service / Controller 구현**  
  - `/api/checker/check` API 완성
  - ProofCheckRequest → domain 변환 → 채점 → ErrorResponse 리스트 반환

- **테스트용 JSON 추가 (DOCS)**  
  - 엔드포인트 수동 테스트용 샘플 데이터 제공

---

## 🔬 테스트
- [x] 로컬 테스트 완료
- [x] `/api/checker/check` 정상 응답 확인
- [x] 파싱 오류 / 구조 오류 / 규칙 오류 등 예외 케이스 검증 완료  
  - 잘못된 citation operand  
  - depth 점프  
  - subproof 미종료  
  - invalid premise/conclusion  
  - invalid sentence 처리  

---

## 📝 참고 이슈
Closes #1 